### PR TITLE
Removed space before colon to match Tailwind config

### DIFF
--- a/src/scripts/components/app.vue
+++ b/src/scripts/components/app.vue
@@ -192,7 +192,7 @@ export default {
                     </span>
                     <ul :class="'list-reset italic text-grey p-4 palette-code hex' + palette.color">
                         <li class="pb-2" v-for="(hex, name) in palette.output" :key="`${name}:${hex}`">
-                            '{{ name }}' : '{{ hex.toUpperCase() }}',
+                            '{{ name }}': '{{ hex.toUpperCase() }}',
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
In the default Tailwind config, there's no space in front of the colon.
I've removed the space to match the default Tailwind config