### PR TITLE
added color/shade level 50 like in tailwindui

### DIFF
--- a/src/scripts/components/palette.vue
+++ b/src/scripts/components/palette.vue
@@ -33,6 +33,7 @@ export default {
 
       tintsPerVersion: {
         1: {
+          50: 0.95,
           100: 0.9,
           200: 0.75,
           300: 0.6,


### PR DESCRIPTION
Hi, 

I added support for adding a color/shade level 50, Which have been used in the latest tailwindui.

Example:

```json
'peach-yellow': {
50: '#FEFDFB',
100: '#FEFBF6',
200: '#FCF6E9',
300: '#FAF0DC',
400: '#F7E4C2',
500: '#F3D9A8',
600: '#DBC397',
700: '#928265',
800: '#6D624C',
900: '#494132',
},
```