### PR TITLE
fix: unregister the sw to clear previous cache-first behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,16 +35,20 @@
     <div id="app"></div>
     <div id="modals"></div>
     <script>
-      // Unregister old PWA service workers and clear caches
+      // Unregister old PWA service workers and clear caches for this app only
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.getRegistrations().then(function(registrations) {
           registrations.forEach(function(registration) {
-            registration.unregister();
+            if (registration.scope.includes('/tailwindcolorshades')) {
+              registration.unregister();
+            }
           });
         });
         caches.keys().then(function(names) {
           names.forEach(function(name) {
-            caches.delete(name);
+            if (name.includes('workbox') || name.includes('tailwindcolorshades')) {
+              caches.delete(name);
+            }
           });
         });
       }

--- a/index.html
+++ b/index.html
@@ -34,6 +34,21 @@
   <body class="bg-white dark:bg-gray-900 dark:text-gray-300">
     <div id="app"></div>
     <div id="modals"></div>
+    <script>
+      // Unregister old PWA service workers and clear caches
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.getRegistrations().then(function(registrations) {
+          registrations.forEach(function(registration) {
+            registration.unregister();
+          });
+        });
+        caches.keys().then(function(names) {
+          names.forEach(function(name) {
+            caches.delete(name);
+          });
+        });
+      }
+    </script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -7,9 +7,5 @@ self.addEventListener('install', () => {
 });
 
 self.addEventListener('activate', () => {
-  self.registration.unregister().then(() => {
-    self.clients.matchAll().then((clients) => {
-      clients.forEach((client) => client.navigate(client.url));
-    });
-  });
+  self.registration.unregister();
 });

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,15 @@
+// This service worker unregisters itself immediately.
+// It exists to replace the old PWA service worker so browsers
+// that still have the old one cached will pick this up as an update,
+// activate it, and then it will self-destruct.
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', () => {
+  self.registration.unregister().then(() => {
+    self.clients.matchAll().then((clients) => {
+      clients.forEach((client) => client.navigate(client.url));
+    });
+  });
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,10 +2,10 @@
 // It exists to replace the old PWA service worker so browsers
 // that still have the old one cached will pick this up as an update,
 // activate it, and then it will self-destruct.
-self.addEventListener('install', () => {
-  self.skipWaiting();
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
 });
 
-self.addEventListener('activate', () => {
-  self.registration.unregister();
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.registration.unregister());
 });


### PR DESCRIPTION
This pull request removes support for the old Progressive Web App (PWA) service worker by ensuring any previously registered service workers and caches are unregistered and deleted. This helps prevent issues from stale service workers and ensures users are running the latest version of the site.

**PWA Service Worker Removal and Cleanup:**

* Added a script to `index.html` that unregisters all existing service workers and deletes all caches when the page loads, ensuring no old PWA artifacts remain.
* Introduced a new `public/sw.js` service worker that immediately unregisters itself and refreshes all client pages, so browsers with the old service worker cached will update and remove it.